### PR TITLE
You can now search in the future. And show two connections.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ Connection {{index+1}}
       Current delay {{ bus["delay"] }} min
     {% endif %}
   {% endfor %}
-{% endfor %}```
+{% endfor %}
+```
 
 #### Result
 ```

--- a/README.md
+++ b/README.md
@@ -92,38 +92,53 @@ The next connection short description in format *time (bus line)*. If there are 
 From the **detail attribute** you can access the attributes of the individual connections (there are 2 connections)
 #### You can display them like that this example (for sensor entity_id sensor.cz_pub_tran)
 ```yaml
-{{ states.sensor.cz_pub_tran.attributes["description"][0] }}
+{{ states.sensor.cz_pub_tran.attributes["detail"][0] }}
 ```
 
 #### Result:
 ```
-[{'line': '129', 'depTime': '14:06', 'depStation': 'Zbraslavské náměstí', 'arrTime': '14:16', 'arrStation': 'Lihovar', 'delay': ''}, {'line': '20', 'depTime': '14:25', 'depStation': 'Lihovar', 'arrTime': '14:35', 'arrStation': 'Poliklinika Barrandov', 'delay': ''}]
+[{'line': '241', 'depTime': '23:08', 'depStation': 'Zbraslavské náměstí', 'arrTime': '23:17', 'arrStation': 'Lihovar', 'delay': ''}, {'line': '5', 'depTime': '23:24', 'depStation': 'Lihovar', 'arrTime': '23:33', 'arrStation': 'Poliklinika Barrandov', 'delay': ''}]
 ```
 
 #### Or you can parse them using scipt:
 ```yaml
-{% for bus in states.sensor.cz_pub_tran.attributes["description"][0] %}
-  Line: {{ bus["line"] }}
-  Departure time {{ bus["depTime"] }} from {{ bus["depStation"] }}
-  Arrival time {{ bus["arrTime"] }} to {{ bus["arrStation"] }}
-  {%- if bus["delay"] != "" %}
-    Current delay {{ bus["delay"] }} min
-  {% endif %}
-{% endfor %}
-```
+{% for index in [0,1] %}
+Connection {{index+1}}
+  {% for bus in states.sensor.cz_pub_tran.attributes["detail"][index] %}
+    Line: {{ bus["line"] }}
+    Departure time {{ bus["depTime"] }} from {{ bus["depStation"] }}
+    Arrival time {{ bus["arrTime"] }} to {{ bus["arrStation"] }}
+    {%- if bus["delay"] != "" %}
+      Current delay {{ bus["delay"] }} min
+    {% endif %}
+  {% endfor %}
+{% endfor %}```
 
 #### Result
 ```
-  Line: 129
-  Departure time 14:06 from Zbraslavské náměstí
-  Arrival time 14:16 to Lihovar
+Connection 1
+  
+    Line: 129
+    Departure time 22:48 from Zbraslavské náměstí
+    Arrival time 22:57 to Lihovar
+  
+    Line: 5
+    Departure time 23:04 from Lihovar
+    Arrival time 23:13 to Poliklinika Barrandov
+  
 
-  Line: 20
-  Departure time 14:25 from Lihovar
-  Arrival time 14:35 to Poliklinika Barrandov
+Connection 2
+  
+    Line: 241
+    Departure time 23:08 from Zbraslavské náměstí
+    Arrival time 23:17 to Lihovar
+  
+    Line: 5
+    Departure time 23:24 from Lihovar
+    Arrival time 23:33 to Poliklinika Barrandov
 ```
 
-For the second connection you'd use **sensor.cz_pub_tran.attributes["description"][1]**
+For the second connection you'd use **states.sensor.cz_pub_tran.attributes["detail"][1]**
 
 ---
 <a href="https://www.buymeacoffee.com/3nXx0bJDP" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/white_img.png" alt="Buy Me A Coffee" style="height: auto !important;width: auto !important;" ></a>

--- a/README.md
+++ b/README.md
@@ -138,8 +138,5 @@ Connection 2
     Departure time 23:24 from Lihovar
     Arrival time 23:33 to Poliklinika Barrandov
 ```
-
-For the second connection you'd use **states.sensor.cz_pub_tran.attributes["detail"][1]**
-
 ---
 <a href="https://www.buymeacoffee.com/3nXx0bJDP" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/white_img.png" alt="Buy Me A Coffee" style="height: auto !important;width: auto !important;" ></a>

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ Set the time to start searching for connections
 
 | Attribute | Description
 |:---------|-----------
-| `entity_id` | ID of the sensor (e.g. sensor.bus_to_work)
-| `start_time` | The starting time. Call the service without this parameter to remove the start time (search from the current time)
+| `entity_id` | ID of the sensor (e.g. `sensor.bus_to_work`)
+| `start_time` | The starting time (e.g. `'19:30'`). Call the service without this parameter to remove the start time (search from the current time)
 
 
 ## ADVANCED - parsing list description

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ The next connection short description in format *time (bus line)*. If there are 
 
 ## SERVICE sensor.set_start_time
 Set the time to start searching for connections
+
 | Attribute | Description
 |:---------|-----------
 | `entity_id` | ID of the sensor (e.g. sensor.bus_to_work)

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ cz_pub_tran:
 | `user_id` | Yes | ...if you have one (if you do, please let me know where you got it. Thanks!). Otherwise it will use the trial account. 
 | `scan_interval` | Yes | The sensor refresh rate (seconds)<br/>**Default**: 60
 | `force_refresh_period` | Yes | The sensor will skip update if there is already scheduled connection. But, every n-th refresh, it will force the update, to check delay changes. This can be disabled by setting this to 0.<br/>**Default**: 5  **Range**: 0-60
-| `description_format` | Yes | The **description** attribute can be rendered in 3 different formats:<br/>- **text**: plain text, each connection on 1 line (**default**)<br/>- **HTML**: HTML table<br/>- **list**: list of lidividual lines - see [bellow for example use](#Advanced---parsing-list-description)
+| `description_format` | Yes | The **description** attribute can be rendered in 2 different formats:<br/>- **text**: plain text, each connection on 1 line (**default**)<br/>- **HTML**: HTML table
 | `name` | Yes | Sensor friendly name.<br/>**Default**: cz_pub_tran
 | `origin` | No | Name of the originating bus stop
 | `destination` | No | Name of the destination bus stop
@@ -85,13 +85,14 @@ The next connection short description in format *time (bus line)*. If there are 
 | `connections` | List of the connections to take (or simply line number if this is a direct connection)
 | `duration` | Trip duration
 | `delay` | Dlayed connections (including the line number and the delay)
-| `description` | Full description of the connections - each connection on 1 line, in the format<br/>*line time (bus stop to get-in) -> time (bus stop to get-off)   (!!! delay if applicable)*<br/>Or a list of connection if **description_format** parameter is set to **list**
+| `description` | Full description of the connections - each connection on 1 line, in the format<br/>*line time (bus stop to get-in) -> time (bus stop to get-off)   (!!! delay if applicable)*,<br/>or as a HTML table
+| `detail` | A list of 2 connections. Each connection is a dictionary of values (see the example below)
 
 ### Advanced - parsing list description
-If you have configured the **description_format** as list, you can access the attributes of the individual connections.
-#### You can display them like that this example
+From the **detail attribute** you can access the attributes of the individual connections (there are 2 connections)
+#### You can display them like that this example (for sensor entity_id sensor.cz_pub_tran)
 ```yaml
-{{ states.sensor.cz_pub_tran.attributes["description"] }}
+{{ states.sensor.cz_pub_tran.attributes["description"][0] }}
 ```
 
 #### Result:
@@ -101,7 +102,7 @@ If you have configured the **description_format** as list, you can access the at
 
 #### Or you can parse them using scipt:
 ```yaml
-{% for bus in states.sensor.cz_pub_tran.attributes["description"] %}
+{% for bus in states.sensor.cz_pub_tran.attributes["description"][0] %}
   Line: {{ bus["line"] }}
   Departure time {{ bus["depTime"] }} from {{ bus["depStation"] }}
   Arrival time {{ bus["arrTime"] }} to {{ bus["arrStation"] }}
@@ -121,6 +122,8 @@ If you have configured the **description_format** as list, you can access the at
   Departure time 14:25 from Lihovar
   Arrival time 14:35 to Poliklinika Barrandov
 ```
+
+For the second connection you'd use **sensor.cz_pub_tran.attributes["description"][1]**
 
 ---
 <a href="https://www.buymeacoffee.com/3nXx0bJDP" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/white_img.png" alt="Buy Me A Coffee" style="height: auto !important;width: auto !important;" ></a>

--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ cz_pub_tran:
 | `combination_id` | Yes | Name of the combination of timetables.<br/>**Default**: `ABCz`
 
 ## STATE AND ATTRIBUTES
-### State
+### STATE
 The next connection short description in format *time (bus line)*. If there are line changes to be made, the status will only show the first connection (see attribute description for the complete plan)
 
-### Attributes
+### ATTRIBUTES
 | Attribute | Description
 |:---------|-----------
 | `departure` | Departure time
@@ -89,19 +89,27 @@ The next connection short description in format *time (bus line)*. If there are 
 | `description` | Full description of the connections - each connection on 1 line, in the format<br/>*line time (bus stop to get-in) -> time (bus stop to get-off)   (!!! delay if applicable)*,<br/>or as a HTML table
 | `detail` | A list of 2 connections. Each connection is a dictionary of values (see the example below)
 
-### Advanced - parsing list description
+## SERVICE sensor.set_start_time
+Set the time to start searching for connections
+| Attribute | Description
+|:---------|-----------
+| `entity_id` | ID of the sensor (e.g. sensor.bus_to_work)
+| `start_time` | The starting time. Call the service without this parameter to remove the start time (search from the current time)
+
+
+## ADVANCED - parsing list description
 From the **detail attribute** you can access the attributes of the individual connections (there are 2 connections)
-#### You can display them like that this example (for sensor entity_id sensor.cz_pub_tran)
+### You can display them like that this example (for sensor entity_id sensor.cz_pub_tran)
 ```yaml
 {{ states.sensor.cz_pub_tran.attributes["detail"][0] }}
 ```
 
-#### Result:
+### Result:
 ```
 [{'line': '241', 'depTime': '23:08', 'depStation': 'Zbraslavské náměstí', 'arrTime': '23:17', 'arrStation': 'Lihovar', 'delay': ''}, {'line': '5', 'depTime': '23:24', 'depStation': 'Lihovar', 'arrTime': '23:33', 'arrStation': 'Poliklinika Barrandov', 'delay': ''}]
 ```
 
-#### Or you can parse them using scipt:
+### Or you can parse them using scipt:
 ```yaml
 {% for index in [0,1] %}
 Connection {{index+1}}
@@ -116,7 +124,7 @@ Connection {{index+1}}
 {% endfor %}
 ```
 
-#### Result
+### Result
 ```
 Connection 1
   

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ cz_pub_tran:
 cz_pub_tran:
   user_id: <no idea where to get one>
   scan_interval: 120
-  force_refresh_interval: 5
+  force_refresh_period: 0
   detail_format: HTML
   sensors:
     - name: "Zbraslav-Barrandov"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 The `CZ-Public-Transport` component is a Home Assistant custom sensor that finds Public Transport connections in the Czech Republic. It uses test version of CRWS - an REST API managed by CHAPS s.r.o. The test version is unfortunately limited to limited combinations of connections - ABCz, witch is PID (Pražská Integrovaná Doprava) without trains. The full version would require client ID, but CHAPS does not provide that to public as far as I know. I did write them an email about my intention to write this sensor, but they did not respond. 
 
 <img src="https://github.com/bruxy70/CZ-Public-Transport/blob/master/images/overview.png">
-Overview (using standard picture-elements card - with the take as background image)
+Overview (using standard picture-elements card - with the table in background image)
+
 
 <img src="https://github.com/bruxy70/CZ-Public-Transport/blob/master/images/connection.png">
 Connection detail (using markdown custom card, displayed as popup-card)

--- a/custom_components/cz_pub_tran/__init__.py
+++ b/custom_components/cz_pub_tran/__init__.py
@@ -74,7 +74,7 @@ class ConnectionPlatform():
             if entity.scheduled_connection(self._force_refresh_period):
                 # _LOGGER.debug( f'({entity._name}) departure already scheduled for {entity._departure} - not checking connections')
                 continue
-            if await self._api.async_find_connection(entity._origin,entity._destination,entity._combination_id):
+            if await self._api.async_find_connection(entity._origin,entity._destination,entity._combination_id,entity._start_time):
                 description = DESCRIPTION_HEADER[self._description_format]
                 connections=''
                 delay=''

--- a/custom_components/cz_pub_tran/__init__.py
+++ b/custom_components/cz_pub_tran/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.const import (
     CONF_SCAN_INTERVAL,
     CONF_SENSORS,
+    CONF_ENTITY_ID,
     CONF_NAME
 )
 from .constants import (
@@ -29,6 +30,8 @@ from .sensor import (
     CONF_FORCE_REFRESH_PERIOD,
     CONF_DESCRIPTION_FORMAT,
     CONFIG_SCHEMA,
+    SET_START_TIME_SCHEMA,
+    ATTR_START_TIME,  
     COMPONENT_NAME
 )
 
@@ -46,6 +49,7 @@ async def async_setup(hass, config):
     session = async_get_clientsession(hass)
     hass.data[DOMAIN]= ConnectionPlatform(hass,user_id,scan_interval,force_refresh_period,description_format,session)
     hass.helpers.discovery.load_platform(COMPONENT_NAME,DOMAIN, conf[CONF_SENSORS], config)
+    hass.services.async_register(DOMAIN, 'set_start_time', hass.data[DOMAIN].handle_set_time, schema=SET_START_TIME_SCHEMA)
     async_call_later(hass,1, hass.data[DOMAIN].async_update_Connections())
     return True
 
@@ -59,6 +63,20 @@ class ConnectionPlatform():
         self._entity_ids = []
         self._connections = []
         self._api = czpubtran(session,user_id)
+
+    def handle_set_time(self,call):
+        """Handle the cz_pub_tran.set_time call"""
+        _time = call.data.get(ATTR_START_TIME)
+        _entity_id = call.data.get(CONF_ENTITY_ID)
+        if _time is None:
+            _LOGGER.debug(f'Received call to reset the start time in {_entity_id}')
+        else:
+            _LOGGER.debug(f'Received call to set the start time in entity {_entity_id} to {_time}')
+        entity = next((entity for entity in self._connections if entity.entity_id==_entity_id),None)
+        if entity is not None: 
+            entity._start_time=None if _time is None else _time.strftime("%H:%M")
+            entity.load_defaults()
+            async_call_later(self._hass,0, self.async_update_Connections())
 
     def add_sensor(self,sensor):
         self._connections.append(sensor)

--- a/custom_components/cz_pub_tran/constants.py
+++ b/custom_components/cz_pub_tran/constants.py
@@ -4,7 +4,6 @@ Text constants for cz_pub_tran sensor
 
 DESCRIPTION_HEADER = {
     'text': '',
-    'list': '',
     'HTML': '<table>\n'
             '<tr>'
             '<th align="left">Line</th>'
@@ -18,18 +17,15 @@ DESCRIPTION_HEADER = {
 
 DESCRIPTION_LINE_DELAY = {
     'text': '{:<4} {:<5} ({}) -> {:<5} ({})   !!! {}min delayed',
-    'list': '{:<4} {:<5} ({}) -> {:<5} ({})   !!! {}min delayed',
     'HTML': '<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}min</td></tr>'
 }
 
 DESCRIPTION_LINE_NO_DELAY = {
     'text': '{:<4} {:<5} ({}) -> {:<5} ({})',
-    'list': '{:<4} {:<5} ({}) -> {:<5} ({})',
     'HTML': '<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td></td></tr>'
 }
 
 DESCRIPTION_FOOTER = {
     'text': '',
-    'list': '',
     'HTML': '\n</table>'
 }

--- a/custom_components/cz_pub_tran/manifest.json
+++ b/custom_components/cz_pub_tran/manifest.json
@@ -2,7 +2,7 @@
   "domain": "cz_pub_tran",
   "name": "CZ Public Transport",
   "documentation": "https://github.com/bruxy70/CZ-Public-Transport/",
-  "requirements": ["czpubtran==0.1.13"],
+  "requirements": ["czpubtran==0.1.14"],
   "dependencies": [],
   "codeowners": ["@bruxy70"]
 }

--- a/custom_components/cz_pub_tran/manifest.json
+++ b/custom_components/cz_pub_tran/manifest.json
@@ -2,7 +2,7 @@
   "domain": "cz_pub_tran",
   "name": "CZ Public Transport",
   "documentation": "https://github.com/bruxy70/CZ-Public-Transport/",
-  "requirements": ["czpubtran==0.1.15"],
+  "requirements": ["czpubtran==0.1.17"],
   "dependencies": [],
   "codeowners": ["@bruxy70"]
 }

--- a/custom_components/cz_pub_tran/manifest.json
+++ b/custom_components/cz_pub_tran/manifest.json
@@ -2,7 +2,7 @@
   "domain": "cz_pub_tran",
   "name": "CZ Public Transport",
   "documentation": "https://github.com/bruxy70/CZ-Public-Transport/",
-  "requirements": ["czpubtran==0.1.17"],
+  "requirements": ["czpubtran==0.1.16"],
   "dependencies": [],
   "codeowners": ["@bruxy70"]
 }

--- a/custom_components/cz_pub_tran/manifest.json
+++ b/custom_components/cz_pub_tran/manifest.json
@@ -2,7 +2,7 @@
   "domain": "cz_pub_tran",
   "name": "CZ Public Transport",
   "documentation": "https://github.com/bruxy70/CZ-Public-Transport/",
-  "requirements": ["czpubtran==0.1.16"],
+  "requirements": ["czpubtran==0.1.18"],
   "dependencies": [],
   "codeowners": ["@bruxy70"]
 }

--- a/custom_components/cz_pub_tran/manifest.json
+++ b/custom_components/cz_pub_tran/manifest.json
@@ -2,7 +2,7 @@
   "domain": "cz_pub_tran",
   "name": "CZ Public Transport",
   "documentation": "https://github.com/bruxy70/CZ-Public-Transport/",
-  "requirements": ["czpubtran==0.1.14"],
+  "requirements": ["czpubtran==0.1.15"],
   "dependencies": [],
   "codeowners": ["@bruxy70"]
 }

--- a/custom_components/cz_pub_tran/sensor.py
+++ b/custom_components/cz_pub_tran/sensor.py
@@ -36,6 +36,7 @@ ATTR_DEPARTURE = "departure"
 ATTR_CONNECTIONS = "connections"
 ATTR_DESCRIPTION = "description"
 ATTR_DETAIL = "detail"
+ATTR_START_TIME = "start_time"
 ATTR_DELAY = "delay"
 
 TRACKABLE_DOMAINS = ["sensor"]
@@ -90,6 +91,7 @@ class CZPubTranSensor(Entity):
         self._destination = config.get(CONF_DESTINATION)
         self._combination_id = config.get(CONF_COMBINATION_ID)
         self._forced_refresh_countdown = 1
+        self._start_time = None
         self.load_defaults()
         # _LOGGER.debug(f'Entity {self._name} inicialized')
 
@@ -112,6 +114,7 @@ class CZPubTranSensor(Entity):
         res[ATTR_DELAY] = self._delay
         res[ATTR_CONNECTIONS] = self._connections
         res[ATTR_DESCRIPTION] = self._description
+        res[ATTR_START_TIME] = self._start_time
         res[ATTR_DETAIL] = self._detail
         return res
 

--- a/custom_components/cz_pub_tran/sensor.py
+++ b/custom_components/cz_pub_tran/sensor.py
@@ -93,7 +93,6 @@ class CZPubTranSensor(Entity):
         self._forced_refresh_countdown = 1
         self._start_time = None
         self.load_defaults()
-        # _LOGGER.debug(f'Entity {self._name} inicialized')
 
     @property
     def name(self):
@@ -126,26 +125,21 @@ class CZPubTranSensor(Entity):
         """Return False if Connection needs to be updated."""
         try:
             if self._forced_refresh_countdown <= 0 or self._departure == '':
-                # _LOGGER.debug(f'Entity {self.entity_id} - Refreshing - forced refresh countdown expired')
                 self._forced_refresh_countdown = forced_refresh_period if forced_refresh_period > 0 else 1
                 return False
             departure_time=datetime.strptime(self._departure,"%H:%M").time()
             now=datetime.now().time()
             connection_valid = bool(now < departure_time or ( now.hour> 22 and departure_time < 6 ))
             if forced_refresh_period == 0:
-                # _LOGGER.debug(f'Entity {self.entity_id} - Forced refresh disabled - Connection valid? {connection_valid}')
                 return bool(now < departure_time or ( now.hour> 22 and departure_time < 6 ))
             else:
                 if connection_valid:
                     self._forced_refresh_countdown -= 1
-                    # _LOGGER.debug(f'Entity {self.entity_id} - Not refreshing - decrementing countdown to {self._forced_refresh_countdown}')
                     return True
                 else:
                     self._forced_refresh_countdown = forced_refresh_period
-                    # _LOGGER.debug(f'Entity {self.entity_id} - Refreshing - new connection needed')
                     return False
         except:
-            # _LOGGER.debug(f'Entity {self.entity_id} - Refreshing - exception occured')
             return False # Refresh data on Error
 
     def update_status(self,departure,duration,state,connections,description,detail,delay):
@@ -164,4 +158,3 @@ class CZPubTranSensor(Entity):
         """Entity added. Entity ID ready"""
         self.hass.data[DOMAIN].add_entity_id(self.entity_id)
         self.hass.data[DOMAIN].add_sensor(self)
-        # _LOGGER.debug(f'Entity {self.entity_id} added')

--- a/custom_components/cz_pub_tran/sensor.py
+++ b/custom_components/cz_pub_tran/sensor.py
@@ -22,7 +22,7 @@ ENTITY_ID_FORMAT = COMPONENT_NAME + ".{}"
 
 ICON_BUS = "mdi:bus"
 
-DESCRIPTION_FORMAT_OPTIONS = ['HTML','text','list']
+DESCRIPTION_FORMAT_OPTIONS = ['HTML','text']
 
 CONF_ORIGIN = "origin"
 CONF_DESTINATION = "destination"
@@ -35,6 +35,7 @@ ATTR_DURATION = "duration"
 ATTR_DEPARTURE = "departure"
 ATTR_CONNECTIONS = "connections"
 ATTR_DESCRIPTION = "description"
+ATTR_DETAIL = "detail"
 ATTR_DELAY = "delay"
 
 TRACKABLE_DOMAINS = ["sensor"]
@@ -111,6 +112,7 @@ class CZPubTranSensor(Entity):
         res[ATTR_DELAY] = self._delay
         res[ATTR_CONNECTIONS] = self._connections
         res[ATTR_DESCRIPTION] = self._description
+        res[ATTR_DETAIL] = self._detail
         return res
 
     @property
@@ -137,16 +139,17 @@ class CZPubTranSensor(Entity):
         except:
             return False # Refresh data on Error
 
-    def update_status(self,departure,duration,state,connections,description,delay):
+    def update_status(self,departure,duration,state,connections,description,detail,delay):
         self._departure = departure
         self._duration = duration
         self._state = state
         self._connections = connections
         self._description = description
+        self._detail = detail
         self._delay = delay
 
     def load_defaults(self):
-        self.update_status("","","","","","")
+        self.update_status("","","","","",[[],[]],"")
         
     async def async_added_to_hass(self):
         """Entity added. Entity ID ready"""

--- a/custom_components/cz_pub_tran/sensor.py
+++ b/custom_components/cz_pub_tran/sensor.py
@@ -7,6 +7,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.const import (
     CONF_SCAN_INTERVAL,
     CONF_SENSORS,
+    CONF_ENTITY_ID,
     CONF_NAME
 )
 from homeassistant.core import HomeAssistant, State
@@ -55,6 +56,13 @@ SENSOR_SCHEMA = vol.Schema(
         vol.Required(CONF_ORIGIN): cv.string,
         vol.Required(CONF_DESTINATION): cv.string,
         vol.Optional(CONF_COMBINATION_ID, default=DEFAULT_COMBINATION_ID): cv.string,
+    }
+)
+
+SET_START_TIME_SCHEMA = vol.Schema(
+    {
+        vol.Optional(ATTR_START_TIME): cv.time,
+        vol.Required(CONF_ENTITY_ID): cv.string,
     }
 )
 

--- a/custom_components/cz_pub_tran/sensor.py
+++ b/custom_components/cz_pub_tran/sensor.py
@@ -126,20 +126,26 @@ class CZPubTranSensor(Entity):
         """Return False if Connection needs to be updated."""
         try:
             if self._forced_refresh_countdown <= 0 or self._departure == '':
+                # _LOGGER.debug(f'Entity {self.entity_id} - Refreshing - forced refresh countdown expired')
                 self._forced_refresh_countdown = forced_refresh_period if forced_refresh_period > 0 else 1
                 return False
             departure_time=datetime.strptime(self._departure,"%H:%M").time()
             now=datetime.now().time()
+            connection_valid = bool(now < departure_time or ( now.hour> 22 and departure_time < 6 ))
             if forced_refresh_period == 0:
+                # _LOGGER.debug(f'Entity {self.entity_id} - Forced refresh disabled - Connection valid? {connection_valid}')
                 return bool(now < departure_time or ( now.hour> 22 and departure_time < 6 ))
             else:
-                if now < departure_time or ( now.hour> 22 and departure_time < 6 ):
+                if connection_valid:
                     self._forced_refresh_countdown -= 1
+                    # _LOGGER.debug(f'Entity {self.entity_id} - Not refreshing - decrementing countdown to {self._forced_refresh_countdown}')
                     return True
                 else:
                     self._forced_refresh_countdown = forced_refresh_period
+                    # _LOGGER.debug(f'Entity {self.entity_id} - Refreshing - new connection needed')
                     return False
         except:
+            # _LOGGER.debug(f'Entity {self.entity_id} - Refreshing - exception occured')
             return False # Refresh data on Error
 
     def update_status(self,departure,duration,state,connections,description,detail,delay):

--- a/custom_components/cz_pub_tran/services.yaml
+++ b/custom_components/cz_pub_tran/services.yaml
@@ -1,0 +1,9 @@
+set_start_time:
+  description: Search for the connections starting from time onwards.
+  fields:
+    entity_id:
+      description: Name of the cz_pub_tran sensor to set the start time 
+      example: "sensor.cz_pub_tran_1"
+    start_time:
+      description: The start time. Call the service without this parameter to remove the start time (search from the current time)
+      example: "18:00"

--- a/custom_components/cz_pub_tran/services.yaml
+++ b/custom_components/cz_pub_tran/services.yaml
@@ -3,7 +3,7 @@ set_start_time:
   fields:
     entity_id:
       description: Name of the cz_pub_tran sensor to set the start time 
-      example: "sensor.cz_pub_tran_1"
+      example: sensor.bus_to_work
     start_time:
       description: The start time. Call the service without this parameter to remove the start time (search from the current time)
-      example: "18:00"
+      example: '18:00'

--- a/info.md
+++ b/info.md
@@ -3,7 +3,8 @@
 The `CZ-Public-Transport` component is a Home Assistant custom sensor that finds Public Transport connections in the Czech Republic. It uses test version of CRWS - an REST API managed by CHAPS s.r.o. The test version is unfortunately limited to limited combinations of connections - ABCz, witch is PID (Pražská Integrovaná Doprava) without trains. The full version would require client ID, but CHAPS does not provide that to public as far as I know. I did write them an email about my intention to write this sensor, but they did not respond.
 
 <img src="https://github.com/bruxy70/CZ-Public-Transport/blob/master/images/overview.png">
-Overview (using standard picture-elements card - with the take as background image)
+Overview (using standard picture-elements card - with the table in background image)
+
 
 <img src="https://github.com/bruxy70/CZ-Public-Transport/blob/master/images/connection.png">
 Connection detail (using markdown custom card, displayed as popup-card)

--- a/info.md
+++ b/info.md
@@ -39,10 +39,10 @@ For more detailed configuration please look at the <a href="https://github.com/b
 | `combination_id` | Yes | Name of the combination of timetables.<br/>**Default**: `ABCz`
 
 ## STATE AND ATTRIBUTES
-### State
+### STATE
 The next connection short description in format *time (bus line)*. If there are line changes to be made, the status will only show the first connection (see attribute description for the complete plan)
 
-### Attributes
+### ATTRIBUTES
 | Attribute | Description
 |:---------|-----------
 | `departure` | Departure time
@@ -52,6 +52,9 @@ The next connection short description in format *time (bus line)*. If there are 
 | `delay` | Dlayed connections (including the line number and the delay)
 | `description` | Full description of the connections - each connection on 1 line, in the format<br/>*line time (bus stop to get-in) -> time (bus stop to get-off)   (!!! delay if applicable)*,<br/>or as a HTML table
 | `detail` | A list of 2 connections. Each connection is a dictionary of values (see the example at the end of <a href="https://github.com/bruxy70/CZ-Public-Transport/blob/master/README.md">README.md</a>)
+
+## SERVICE sensor.set_start_time
+Set the time to start searching for connections - see <a href="https://github.com/bruxy70/CZ-Public-Transport/blob/master/README.md">README.md</a>) for details
 
 ---
 <a href="https://www.buymeacoffee.com/3nXx0bJDP" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/white_img.png" alt="Buy Me A Coffee" style="height: auto !important;width: auto !important;" ></a>

--- a/info.md
+++ b/info.md
@@ -22,7 +22,7 @@ cz_pub_tran:
 
 ```
 
-For more detailed configuration please look at the <a href="https://github.com/bruxy70/CZ-Public-Transport/blob/master/README.md">README.md</a> file
+For more detailed configuration please look at the <a href="https://github.com/bruxy70/CZ-Public-Transport/blob/master/README.md">README.md</a>
 
 ### CONFIGURATION PARAMETERS
 | Attribute | Optional | Description
@@ -31,7 +31,7 @@ For more detailed configuration please look at the <a href="https://github.com/b
 | `user_id` | Yes | ...if you have one (if you do, please let me know where you got it. Thanks!). Otherwise it will use the trial account. 
 | `scan_interval` | Yes | The sensor refresh rate (seconds)<br/>**Default**: 60
 | `force_refresh_period` | Yes | The sensor will skip update if there is already scheduled connection. But, every n-th refresh, it will force the update, to check delay changes. This can be disabled by setting this to 0.<br/>**Default**: 5  **Range**: 0-60
-| `description_format` | Yes | The **description** attribute can be rendered in 3 different formats:<br/>- **text**: plain text, each connection on 1 line (**default**)<br/>- **HTML**: HTML table<br/>- **list**: list of lidividual lines - you have to use script to render results in whatever format you need
+| `description_format` | Yes | The **description** attribute can be rendered in 2 different formats:<br/>- **text**: plain text, each connection on 1 line (**default**)<br/>- **HTML**: HTML table
 | `name` | Yes | Sensor friendly name.<br/>**Default**: cz_pub_tran
 | `origin` | No | Name of the originating bus stop
 | `destination` | No | Name of the destination bus stop
@@ -49,7 +49,8 @@ The next connection short description in format *time (bus line)*. If there are 
 | `connections` | List of the connections to take (or simply line number if this is a direct connection)
 | `duration` | Trip duration
 | `delay` | Dlayed connections (including the line number and the delay)
-| `description` | Full description of the connections - each connection on 1 line, in the format<br/>*line time (bus stop to get-in) -> time (bus stop to get-off)   (!!! delay if applicable)*<br/>Or a list of connection if **description_format** parameter is set to **list**
+| `description` | Full description of the connections - each connection on 1 line, in the format<br/>*line time (bus stop to get-in) -> time (bus stop to get-off)   (!!! delay if applicable)*,<br/>or as a HTML table
+| `detail` | A list of 2 connections. Each connection is a dictionary of values (see the example at the end of <a href="https://github.com/bruxy70/CZ-Public-Transport/blob/master/README.md">README.md</a>)
 
 ---
 <a href="https://www.buymeacoffee.com/3nXx0bJDP" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/white_img.png" alt="Buy Me A Coffee" style="height: auto !important;width: auto !important;" ></a>


### PR DESCRIPTION
## New features
- Service `set_start_time` allows setting the start time to look for connections - see README for more information
- New attribute `detail` contains two connections with full detail - see README for examples

## Changes - Minor breaking change
Removed option `list` for `description_format` - the new attribute `detail` always contains the list of connections (and unlike the previous version, it contains two connections - so `attributes["detail"][0]` is the same as previously `attributes["description"]` with `list` in `description_format`.

## Fixes
Fixe issue #9 - refreshing timetable combination ID every day, even if it is valid.