### PR TITLE
Add offset configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ cz_pub_tran:
 | `origin` | No | Name of the originating bus stop
 | `destination` | No | Name of the destination bus stop
 | `combination_id` | Yes | Name of the combination of timetables.<br/>**Default**: `ABCz`
+| `offset` | Yes | Offset for a search start time (in seconds). Represents the time needed to walk to the bus stop.<br/>**Default**: `0`
 
 ## STATE AND ATTRIBUTES
 ### STATE

--- a/custom_components/cz_pub_tran/__init__.py
+++ b/custom_components/cz_pub_tran/__init__.py
@@ -204,11 +204,21 @@ class ConnectionPlatform:
                 #     f'for {entity.departure} - not checking connections'
                 # )
                 continue
+            if entity.offset:
+                _offset_delta = timedelta(seconds=entity.offset)
+                if entity.start_time is None:
+                    entity.start_time_incl_offset = \
+                        (datetime.now() + _offset_delta).strftime("%H:%M")
+                else:
+                    _start_datetime = datetime.strptime(entity.start_time, "%H:%M")
+                    entity.start_time_incl_offset = \
+                        (_start_datetime + _offset_delta).strftime("%H:%M")
+
             if await self.__api.async_find_connection(
                 entity.origin,
                 entity.destination,
                 entity.combination_id,
-                entity.start_time,
+                entity.start_time_incl_offset or entity.start_time,
             ):
                 description = DESCRIPTION_HEADER[self.__description_format]
                 connections = ""

--- a/custom_components/cz_pub_tran/constants.py
+++ b/custom_components/cz_pub_tran/constants.py
@@ -51,6 +51,7 @@ DESCRIPTION_FORMAT_OPTIONS = ["HTML", "text"]
 
 CONF_ORIGIN = "origin"
 CONF_DESTINATION = "destination"
+CONF_OFFSET = "offset"
 CONF_USERID = "userId"
 CONF_COMBINATION_ID = "combination_id"
 CONF_FORCE_REFRESH_PERIOD = "force_refresh_period"
@@ -62,6 +63,7 @@ ATTR_CONNECTIONS = "connections"
 ATTR_DESCRIPTION = "description"
 ATTR_DETAIL = "detail"
 ATTR_START_TIME = "start_time"
+ATTR_START_TIME_INCL_OFFSET = "start_time_incl_offset"
 ATTR_DELAY = "delay"
 
 TRACKABLE_DOMAINS = ["sensor"]
@@ -70,6 +72,7 @@ DEFAULT_SCAN_INTERVAL = timedelta(seconds=60)
 DEFAULT_FORCE_REFRESH_PERIOD = 5
 DEFAULT_DESCRIPTION_FORMAT = "text"
 DEFAULT_COMBINATION_ID = "ABCz"
+DEFAULT_OFFSET = 0
 DEFAULT_NAME = "cz_pub_tran"
 
 SENSOR_SCHEMA = vol.Schema(
@@ -77,6 +80,7 @@ SENSOR_SCHEMA = vol.Schema(
         vol.Required(CONF_NAME): cv.string,
         vol.Required(CONF_ORIGIN): cv.string,
         vol.Required(CONF_DESTINATION): cv.string,
+        vol.Optional(CONF_OFFSET, default=DEFAULT_OFFSET): cv.positive_int,
         vol.Optional(CONF_COMBINATION_ID, default=DEFAULT_COMBINATION_ID): cv.string,
     }
 )

--- a/custom_components/cz_pub_tran/sensor.py
+++ b/custom_components/cz_pub_tran/sensor.py
@@ -18,6 +18,7 @@ from .constants import (
     DESCRIPTION_FORMAT_OPTIONS,
     CONF_ORIGIN,
     CONF_DESTINATION,
+    CONF_OFFSET,
     CONF_USERID,
     CONF_COMBINATION_ID,
     CONF_FORCE_REFRESH_PERIOD,
@@ -28,6 +29,7 @@ from .constants import (
     ATTR_DESCRIPTION,
     ATTR_DETAIL,
     ATTR_START_TIME,
+    ATTR_START_TIME_INCL_OFFSET,
     ATTR_DELAY,
     SENSOR_SCHEMA,
 )
@@ -65,10 +67,12 @@ class CZPubTranSensor(Entity):
         self.__name = config.get(CONF_NAME)
         self.__origin = config.get(CONF_ORIGIN)
         self.__destination = config.get(CONF_DESTINATION)
+        self.__offset = config.get(CONF_OFFSET)
         self.__combination_id = config.get(CONF_COMBINATION_ID)
         self.__forced_refresh_countdown = 1
         self.__unique_id = config.get("unique_id", None)
         self.__start_time = None
+        self.__start_time_incl_offset = None
         self.load_defaults()
 
     @property
@@ -87,6 +91,11 @@ class CZPubTranSensor(Entity):
         return self.__destination
 
     @property
+    def offset(self):
+        """Return the offset."""
+        return self.__offset
+
+    @property
     def combination_id(self):
         """Return the combination id."""
         return self.__combination_id
@@ -100,6 +109,16 @@ class CZPubTranSensor(Entity):
     def start_time(self, value):
         """Sets start time property"""
         self.__start_time = value
+
+    @property
+    def start_time_incl_offset(self):
+        """Return the start time incl. offset."""
+        return self.__start_time_incl_offset
+
+    @start_time_incl_offset.setter
+    def start_time_incl_offset(self, value):
+        """Sets start time property (incl. offset)"""
+        self.__start_time_incl_offset = value
 
     @property
     def state(self):
@@ -116,6 +135,7 @@ class CZPubTranSensor(Entity):
         res[ATTR_CONNECTIONS] = self.__connections
         res[ATTR_DESCRIPTION] = self.__description
         res[ATTR_START_TIME] = self.__start_time
+        res[ATTR_START_TIME_INCL_OFFSET] = self.__start_time_incl_offset
         res[ATTR_DETAIL] = self.__detail
         return res
 


### PR DESCRIPTION
Motivation: walking distance from my home to the bus stop is around
5 minutes. Sensor usually displays a departure that I won't be able to
catch.

This commit introduces a new parameter "offset" which is a positive
integer value in seconds.
On each updated of departures sensor will check availability of the
offset parameter and it will add it to the start_time.
In the CZPubTran library (not the sensor) there is no value attached
to the payload if start_time is None. It is one of the drawbacks
of the current implementation as sensors gets current time on
home assistant instance and there might be a delay while it will submit
the request and update the sensor. Possible workaround is include
sensor update time to the offset.

I've introduced a new sensor attribute to display start time with the
offset. It might be useful to display sensor data while it it searching
for connection and departure time attribute isn't yet available.